### PR TITLE
Fixed #8

### DIFF
--- a/Core/Properties/PropertyNullAnnotator.cs
+++ b/Core/Properties/PropertyNullAnnotator.cs
@@ -32,11 +32,19 @@ namespace NullableReferenceTypesRewriter.Properties
     public override SyntaxNode? VisitPropertyDeclaration (PropertyDeclarationSyntax node)
     {
       if (HasCanBeNullAttribute (node)
-          || GetterReturnsNull (node)
-          || IsUninitialized (node))
+          || IsInClassOrStruct (node)
+          && (GetterReturnsNull (node)
+              || IsUninitialized (node)))
         return node.WithType (NullUtilities.ToNullable (node.Type));
 
       return node;
+    }
+
+    private bool IsInClassOrStruct (PropertyDeclarationSyntax node)
+    {
+      var parent = node.Parent;
+      return parent is ClassDeclarationSyntax
+             || parent is StructDeclarationSyntax;
     }
 
     private bool IsUninitialized (PropertyDeclarationSyntax node)

--- a/Unittests/CompiledSourceFileProvider.cs
+++ b/Unittests/CompiledSourceFileProvider.cs
@@ -81,7 +81,7 @@ namespace NullableReferenceTypesRewriter.UnitTests
       return CompileInClass ("TestClass", methodTemplate);
     }
 
-    private static (SemanticModel, SyntaxNode) CompileInNameSpace (string nameSpaceName, string nameSpaceContent)
+    public static (SemanticModel, SyntaxNode) CompileInNameSpace (string nameSpaceName, string nameSpaceContent)
     {
       var nameSpaceTemplate =
           "using System;\r\n" +

--- a/Unittests/Properties/PropertyNullAnnotatorTest.cs
+++ b/Unittests/Properties/PropertyNullAnnotatorTest.cs
@@ -122,5 +122,20 @@ namespace NullableReferenceTypesRewriter.UnitTests.Properties
 
       Assert.That (annotated, Is.EqualTo (syntax));
     }
+
+    [Test]
+    public void PropertyAnnotator_WithReadonlyPropertyInInterface_DoesNotAnnotateNullable ()
+    {
+      var (semantic, syntax) = CompiledSourceFileProvider.CompileInNameSpace("TestNamespace",
+          @"public interface ITest
+{
+  string Property { get; }
+}");
+      var annotator = new PropertyNullAnnotator (semantic);
+
+      var annotated = annotator.Visit (syntax);
+
+      Assert.That (annotated, Is.EqualTo (syntax));
+    }
   }
 }


### PR DESCRIPTION
PropertyNull annotator now checks whether it runs inside an interface and ignores the initialization rules if it does